### PR TITLE
Authenticate with database name will be override to "admin"

### DIFF
--- a/Sources/MODServer.m
+++ b/Sources/MODServer.m
@@ -96,7 +96,7 @@
     if ([userName length] > 0 && [password length] > 0) {
         const char *dbName;
         
-        if ([databaseName length] == 0) {
+        if ([databaseName length] != 0) {
             dbName = [databaseName UTF8String];
         } else {
             dbName = "admin";


### PR DESCRIPTION
I believe it's a typo.

in `[MODServer authenticateSynchronouslyWithDatabaseName: userName: password: error:]`, the condition

<pre><code>
        if ([databaseName length] == 0) {
            dbName = [databaseName UTF8String];
        } else {
            dbName = "admin";
        } 
</code></pre>


should be swap. 
