### PR TITLE
MongoHub issues with connecting to Config servers.

### DIFF
--- a/Sources/MODServer.h
+++ b/Sources/MODServer.h
@@ -33,6 +33,61 @@ typedef struct mongo                    *mongo_ptr;
     NSString                            *_password;
 }
 
+/**
+ imported from mongo/bson/bsontypes.h
+ 
+ the complete list of valid BSON types
+ see also bsonspec.org
+ */
+
+typedef enum BSONType {
+    /** smaller than all other types */
+    MinKey=-1,
+    /** end of object */
+    EOO=0,
+    /** double precision floating point value */
+    NumberDouble=1,
+    /** character string, stored in utf8 */
+    String=2,
+    /** an embedded object */
+    Object=3,
+    /** an embedded array */
+    Array=4,
+    /** binary data */
+    BinData=5,
+    /** Undefined type */
+    Undefined=6,
+    /** ObjectId */
+    jstOID=7,
+    /** boolean type */
+    Bool=8,
+    /** date type */
+    Date=9,
+    /** null type */
+    jstNULL=10,
+    /** regular expression, a pattern with options */
+    RegEx=11,
+    /** deprecated / will be redesigned */
+    DBRef=12,
+    /** deprecated / use CodeWScope */
+    Code=13,
+    /** a programming language (e.g., Python) symbol */
+    Symbol=14,
+    /** javascript code that can execute on the database server, with SavedContext */
+    CodeWScope=15,
+    /** 32 bit signed integer */
+    NumberInt = 16,
+    /** Updated to a Date with value next OpTime on insert */
+    Timestamp = 17,
+    /** 64 bit integer */
+    NumberLong = 18,
+    /** max type that is not MaxKey */
+    JSTypeMax=18,
+    /** larger than all other types */
+    MaxKey=127
+} real_bson_type;
+
+
 - (void)copyWithCallback:(void (^)(MODServer *copyServer, MODQuery *mongoQuery))callback;
 
 - (MODQuery *)connectWithHostName:(NSString *)host callback:(void (^)(BOOL connected, MODQuery *mongoQuery))callback;

--- a/Sources/MOD_internal.h
+++ b/Sources/MOD_internal.h
@@ -28,6 +28,7 @@ enum {
 @interface MODServer(utils_internal)
 + (NSError *)errorWithErrorDomain:(NSString *)errorDomain code:(NSInteger)code descriptionDetails:(NSString *)descriptionDetails;
 + (NSError *)errorFromMongo:(mongo_ptr)mongo;
++ (bson_type)bsonIteratorNext:(bson_iterator *)iterator;
 + (MODSortedMutableDictionary *)objectFromBson:(bson *)bsonObject;
 + (void)appendObject:(MODSortedMutableDictionary *)object toBson:(bson *)bson;
 @end


### PR DESCRIPTION
MongoHub has issues reading values from mongo config servers because it uses bson_type for iterating and evaluating through the result set, while config servers can return $minKey and $maxKey for some fields and it will crash because of missing enum's.

This patch replaces bson_type for BSONType from bsontypes.h which contains the values and implements is't own bsonIteratorNext which is used instead of the native bson_iterator_next which also has no support for such fields.

Maybe it's not the most beautiful solution, but I have not seen any support for MinKey/MaxKey in the C driver.
